### PR TITLE
Update heroku config in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add database for persistance:
 Configure the app by providing your broker url (RabbitMQ, Redis, what have you) and a password for logging into Flower:
 
     heroku config:set BROKER_URL=redis://...
-    heroku config:set FLOWER_AUTH="username:password"
+    heroku config:set FLOWER_BASIC_AUTH="username:password"
 
 Push to heroku:
 


### PR DESCRIPTION
Replacing FLOWER_AUTH (which is for Google OAuth) by FLOWER_BASIC_AUTH (which is basic auth).
Time saving for new comers.